### PR TITLE
Fixed linker issue when using zig cc

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -1,5 +1,6 @@
 #include "display.h"
-
+enum cull_method cull_method;
+enum render_method render_method;
 SDL_Window* window = NULL;
 SDL_Renderer* renderer = NULL;
 int window_width = 800;

--- a/src/display.h
+++ b/src/display.h
@@ -10,12 +10,12 @@
 #define FPS 60
 #define FRAME_TARGET_TIME (1000 / FPS)
 
-enum cull_method {
+extern enum cull_method {
     CULL_NONE,
     CULL_BACKFACE
 } cull_method;
 
-enum render_method {
+extern enum render_method {
     RENDER_WIRE,
     RENDER_WIRE_VERTEX,
     RENDER_FILL_TRIANGLE,


### PR DESCRIPTION
Fixed
```
zig cc -Wall -std=c99 src/*.c `pkg-config --cflags --libs sdl2` -lm -o renderer
MachO Flush... error(link): symbol '_render_method' defined multiple times
```